### PR TITLE
Adds the deep learning train overview for deep learning 4j as a inter…

### DIFF
--- a/dl4j-examples/pom.xml
+++ b/dl4j-examples/pom.xml
@@ -41,6 +41,11 @@
 
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>org.deeplearning4j</groupId>
+                <artifactId>deeplearning4j-ui_2.10</artifactId>
+                <version>${dl4j.version}</version>
+            </dependency>
            <dependency>
                 <groupId>org.nd4j</groupId>
                 <artifactId>nd4j-native-platform</artifactId>

--- a/dl4j-examples/src/main/java/MachineLearning4555/Wine_2Classes.java
+++ b/dl4j-examples/src/main/java/MachineLearning4555/Wine_2Classes.java
@@ -4,6 +4,7 @@ import org.datavec.api.records.reader.RecordReader;
 import org.datavec.api.records.reader.impl.csv.CSVRecordReader;
 import org.datavec.api.split.FileSplit;
 import org.datavec.api.util.ClassPathResource;
+import org.deeplearning4j.api.storage.StatsStorage;
 import org.deeplearning4j.datasets.datavec.RecordReaderDataSetIterator;
 import org.deeplearning4j.eval.Evaluation;
 import org.deeplearning4j.nn.conf.MultiLayerConfiguration;
@@ -13,6 +14,9 @@ import org.deeplearning4j.nn.conf.layers.OutputLayer;
 import org.deeplearning4j.nn.multilayer.MultiLayerNetwork;
 import org.deeplearning4j.nn.weights.WeightInit;
 import org.deeplearning4j.optimize.listeners.ScoreIterationListener;
+import org.deeplearning4j.ui.api.UIServer;
+import org.deeplearning4j.ui.stats.StatsListener;
+import org.deeplearning4j.ui.storage.InMemoryStatsStorage;
 import org.nd4j.linalg.activations.Activation;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.dataset.DataSet;
@@ -39,8 +43,8 @@ public class Wine_2Classes {
         //number of non-label columns in data set
         int numInputs = 2;
         //number of classes that can be output
-        int numOutputs = 2;
-        int numHiddenNodes = 20;
+        int numOutputs = 3;
+        int numHiddenNodes = 30;
 
         //Data sets
         final String filenameTrain  = new ClassPathResource("4555_Project/wine_3/winemag-data-SET_3-TRAIN.csv").getFile().getPath();
@@ -49,12 +53,12 @@ public class Wine_2Classes {
         //Load the training data:
         RecordReader rr = new CSVRecordReader();
         rr.initialize(new FileSplit(new File(filenameTrain)));
-        DataSetIterator trainIter = new RecordReaderDataSetIterator(rr,batchSize,0,2);
+        DataSetIterator trainIter = new RecordReaderDataSetIterator(rr,batchSize,0,3);
 
         //Load the test/evaluation data:
         RecordReader rrTest = new CSVRecordReader();
         rrTest.initialize(new FileSplit(new File(filenameTest)));
-        DataSetIterator testIter = new RecordReaderDataSetIterator(rrTest,batchSize,0,2);
+        DataSetIterator testIter = new RecordReaderDataSetIterator(rrTest,batchSize,0,3);
 
         //Configure the NN
         MultiLayerConfiguration conf = new NeuralNetConfiguration.Builder()
@@ -71,24 +75,37 @@ public class Wine_2Classes {
                 .nIn(numHiddenNodes).nOut(numHiddenNodes).build())
             .layer(2, new DenseLayer.Builder()
                 .weightInit(WeightInit.XAVIER)
-                .activation(Activation.ELU)
+                .activation(Activation.RELU)
                 .nIn(numHiddenNodes).nOut(numHiddenNodes).build())
-            .layer(3, new OutputLayer.Builder(LossFunction.NEGATIVELOGLIKELIHOOD)
+            .layer(3, new DenseLayer.Builder()
+                .weightInit(WeightInit.XAVIER)
+                .activation(Activation.RELU)
+                .nIn(numHiddenNodes).nOut(numHiddenNodes).build())
+            .layer(4, new OutputLayer.Builder(LossFunction.NEGATIVELOGLIKELIHOOD)
                 .weightInit(WeightInit.XAVIER)
                 .activation(Activation.SOFTMAX).weightInit(WeightInit.XAVIER)
                 .nIn(numHiddenNodes).nOut(numOutputs).build())
-                .pretrain(false).backprop(true).build();
+            .pretrain(false).backprop(true).build();
 
-        //Build the NN
         MultiLayerNetwork model = new MultiLayerNetwork(conf);
         model.init();
+
+        //Initialize the user interface backend
+        UIServer uiServer = UIServer.getInstance();
+
+        //Configure where the network information (gradients, activations, score vs. time etc) is to be stored
+        StatsStorage statsStorage = new InMemoryStatsStorage();
+
         //Print score every 50 parameter updates
-        model.setListeners(new ScoreIterationListener(50));
+        //Add the StatsListener to collect this information from the network, as it trains
+        model.setListeners(new StatsListener(statsStorage), new ScoreIterationListener(50));
 
 
         for ( int n = 0; n < nEpochs; n++) {
             model.fit( trainIter );
         }
+
+        uiServer.attach(statsStorage);
 
         System.out.println("Evaluate model....");
         Evaluation eval = new Evaluation(numOutputs);


### PR DESCRIPTION
…face running on the server(default 9000). This also adds an extra hidden layer which increased the scores and accuracy.
## What changes were proposed in this pull request?
- Server for viewing how the model is training
- Increase model accuracy and score
- To view the interface open your browser and go to http://localhost:9000/train.
- For changing the UI port (usually not necessary) - set the org.deeplearning4j.ui.port system property.
- Therefore, run the example and pass the following to the JVM, to use port 9001: 
`-Dorg.deeplearning4j.ui.port=9001`

Here is the working UI on the port 9000 :
![deep_ui_server](https://user-images.githubusercontent.com/6532730/40460196-19c7e87c-5ecb-11e8-9dcb-9112ff920c74.png)

